### PR TITLE
Fix geth datadir

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -8,6 +8,6 @@ COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN apk update && apk add curl && \ 
     chmod +x /usr/local/bin/entrypoint.sh
 
-ENV GETH_AUTHRPC_ADDR=0.0.0.0 GETH_AUTHRPC_PORT=8551 GETH_AUTHRPC_VHOSTS=* DATADIR=/data
+ENV GETH_AUTHRPC_ADDR=0.0.0.0 GETH_AUTHRPC_PORT=8551 GETH_AUTHRPC_VHOSTS=* GETH_DATADIR=/data
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Fix geth data directory in Dockerfile. The absence of `GETH_DATADIR` in the Dockerfile would cause Holesky geth to sync from scratch on update